### PR TITLE
(GH-22) Add itch.io embed shortcode

### DIFF
--- a/layouts/shortcodes/itchio.html
+++ b/layouts/shortcodes/itchio.html
@@ -1,0 +1,33 @@
+{{- if .IsNamedParams -}}
+  {{- $.Scratch.Set "id"  (.Get "id") -}}
+  {{- $.Scratch.Set "square" (.Get "square") -}}
+  {{- $.Scratch.Set "linkback"  (.Get "linkback") -}}
+  {{- $.Scratch.Set "dark"  (.Get "dark") -}}
+{{- else -}}
+  {{- $.Scratch.Set "id"  (.Get 0) -}}
+  {{- $.Scratch.Set "square" (.Get 1) -}}
+  {{- $.Scratch.Set "linkback"  (.Get 2) -}}
+  {{- $.Scratch.Set "dark"  (.Get 3) -}}
+{{- end -}}
+{{- $.Scratch.Set "url" (printf "https://itch.io/embed/%s" ($.Scratch.Get "id")) -}}
+{{- if (eq ($.Scratch.Get "linkback") "true") -}}
+  {{- $.Scratch.Set "url" (printf "%s?linkback=true" ($.Scratch.Get "url")) -}}
+{{- end -}}
+{{- if (eq ($.Scratch.Get "dark") "true") -}}
+  {{- if strings.HasSuffix ($.Scratch.Get "url") "?linkback=true" -}}
+    {{- $.Scratch.Set "url" (printf "%s&dark=true" ($.Scratch.Get "url")) -}}
+  {{- else -}}
+    {{- $.Scratch.Set "url" (printf "%s?dark=true" ($.Scratch.Get "url")) -}}
+  {{- end -}}
+{{- end -}}
+{{- if (eq ($.Scratch.Get "square") "true") -}}
+  {{ $.Scratch.Set "width" "208"}}
+{{- else -}}
+  {{ $.Scratch.Set "width" "552"}}
+{{- end -}}
+
+<iframe frameborder="0"
+        src="{{ $.Scratch.Get "url" }}"
+        width="{{ $.Scratch.Get "width" }}"
+        height="167">
+</iframe>


### PR DESCRIPTION
This PR adds a new shortcode, itchio, to the theme.

This shortcode takes an id value for the embeddable widget and creates an iframe to host it in the platen site.

The shortcode takes parameters for square, dark mode, and whether or not to include a linkback to the project page.

- Resolves #22