### PR TITLE
Override baseof template.

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="{{ .Site.Language.Lang }}" dir="{{ .Site.Language.LanguageDirection | default "ltr" }}">
+<head>
+    {{ partial "docs/html-head" . }}
+    {{ partial "docs/inject/head" . }}
+
+    {{/* This injects a class based on either cssClass in the _index.md or the filepath. 
+        (The cssClass override is especially useful when the filepath name isn't a valid CSS class name) */}}
+
+    {{ $injectedClass :=  "" }}
+    {{ $currentLink := .Permalink }}
+    {{ $bookSection := default "docs" .Site.Params.BookSection  }}
+
+    {{ if eq $bookSection "*" }}
+        {{ $bookSection = "/" }}
+    {{ end }}
+
+    {{ with .Site.GetPage $bookSection }}
+        {{ range (where .Pages "Params.bookhidden" "ne" true) }}
+            {{ $page := . }}
+            {{ $filePath := replace .File.Path "\\" "/"}}
+            {{ $parts := split $filePath "/" }}
+            {{ $section := index $parts 1 }}
+            {{ $section = replace $section ".md" "" }}
+            {{ if in $currentLink $section }}
+                {{ with $page.Params.cssClass }}
+                    {{ $injectedClass = $page.Params.cssClass }}
+                {{ else }}
+                    {{ $injectedClass = $section }}
+                {{ end }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
+</head>
+<body dir="{{ .Site.Language.LanguageDirection | default "ltr" }}" class="{{ $injectedClass }}">
+  <input type="checkbox" class="hidden toggle" id="menu-control" />
+  <input type="checkbox" class="hidden toggle" id="toc-control" />
+  <main class="container flex">
+    
+
+    <aside class="book-menu">
+      <div class="book-menu-content {{ $injectedClass }}">
+        {{ template "menu" . }} <!-- Left menu Content -->
+      </div>
+    </aside>
+
+    <div class="book-page {{ $injectedClass }}">
+      <header class="book-header">
+        {{ template "header" . }} <!-- Mobile layout header -->
+      </header>
+
+      {{ partial "docs/inject/content-before" . }}
+      {{ template "main" . }} <!-- Page Content -->
+      {{ partial "docs/inject/content-after" . }}
+
+      <footer class="book-footer {{ $injectedClass }}">
+        {{ template "footer" . }} <!-- Footer under page content -->
+        {{ partial "docs/inject/footer" . }}
+      </footer>
+
+      {{ template "comments" . }} <!-- Comments block -->
+
+      <label for="menu-control" class="hidden book-menu-overlay"></label>
+    </div>
+
+    {{ if default true (default .Site.Params.BookToC .Params.BookToC) }}
+    <aside class="book-toc">
+      <div class="book-toc-content {{ $injectedClass }}">
+        {{ template "toc" . }} <!-- Table of Contents -->
+      </div>
+    </aside>
+    {{ end }}
+  </main>
+
+  {{ partial "docs/inject/body" . }}
+</body>
+</html>
+
+{{ define "menu" }}
+  {{ partial "docs/menu" . }}
+{{ end }}
+
+{{ define "header" }}
+  {{ partial "docs/header" . }}
+
+  {{ if default true (default .Site.Params.BookToC .Params.BookToC) }}
+  <aside class="hidden clearfix">
+    {{ template "toc" . }}
+  </aside>
+  {{ end }}
+{{ end }}
+
+{{ define "footer" }}
+  {{ partial "docs/footer" . }}
+{{ end }}
+
+{{ define "comments" }}
+  {{ if and .Content (default true (default .Site.Params.BookComments .Params.BookComments)) }}
+  <div class="book-comments">
+    {{- partial "docs/comments" . -}}
+  </div>
+  {{ end }}
+{{ end }}
+
+{{ define "main" }}
+  <article class="markdown">
+    {{- .Content -}}
+  </article>
+{{ end }}
+
+{{ define "toc" }}
+  {{ partial "docs/toc" . }}
+{{ end }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,6 +9,7 @@
 
     {{ $injectedClass :=  "" }}
     {{ $currentLink := .Permalink }}
+    {{ $currentParams := .Params }}
     {{ $bookSection := default "docs" .Site.Params.BookSection  }}
 
     {{ if eq $bookSection "*" }}
@@ -23,10 +24,14 @@
             {{ $section := index $parts 1 }}
             {{ $section = replace $section ".md" "" }}
             {{ if in $currentLink $section }}
-                {{ with $page.Params.cssClass }}
-                    {{ $injectedClass = $page.Params.cssClass }}
+                {{ with $currentParams.cssClass }}
+                    {{ $injectedClass = $currentParams.cssClass }}
                 {{ else }}
-                    {{ $injectedClass = $section }}
+                    {{ with $page.Params.cssClass }}
+                        {{ $injectedClass = $page.Params.cssClass }}
+                    {{ else }}
+                        {{ $injectedClass = $section }}
+                    {{ end }}
                 {{ end }}
             {{ end }}
         {{ end }}
@@ -39,12 +44,12 @@
     
 
     <aside class="book-menu">
-      <div class="book-menu-content {{ $injectedClass }}">
+      <div class="book-menu-content">
         {{ template "menu" . }} <!-- Left menu Content -->
       </div>
     </aside>
 
-    <div class="book-page {{ $injectedClass }}">
+    <div class="book-page">
       <header class="book-header">
         {{ template "header" . }} <!-- Mobile layout header -->
       </header>
@@ -53,7 +58,7 @@
       {{ template "main" . }} <!-- Page Content -->
       {{ partial "docs/inject/content-after" . }}
 
-      <footer class="book-footer {{ $injectedClass }}">
+      <footer class="book-footer">
         {{ template "footer" . }} <!-- Footer under page content -->
         {{ partial "docs/inject/footer" . }}
       </footer>
@@ -65,7 +70,7 @@
 
     {{ if default true (default .Site.Params.BookToC .Params.BookToC) }}
     <aside class="book-toc">
-      <div class="book-toc-content {{ $injectedClass }}">
+      <div class="book-toc-content">
         {{ template "toc" . }} <!-- Table of Contents -->
       </div>
     </aside>


### PR DESCRIPTION
Overrides the hugo-book template here: https://github.com/alex-shpak/hugo-book/blob/master/layouts/_default/baseof.html

The new code is lines 7-33, the rest (barring the {{ $injectedClass }} refs) should be the same.