### PR TITLE
(GH-39) Extend functionality of class injection

### DIFF
--- a/layouts/partials/platen/getCssClass.html
+++ b/layouts/partials/platen/getCssClass.html
@@ -1,32 +1,58 @@
 {{/*
-    This injects a class based on either cssClass in the _index.md or the filepath.
-    (The cssClass override is especially useful when the filepath name isn't a valid CSS class name)
+    Returns the list of classes, space separated, to inject into the body tag of a page.
+    
+    In particular, the behavior for a page being rendered depends its location:
+    1. If it is a top-level file (e.g. 'content/foo.md'), it will:
+       a. return "foo" if the file's frontmatter does not have the cssClass parameter set
+       b. return the value of the cssClass parameter if set in the file's frontmatter
+       c. return "" if the top-level file is also the homepage (i.e. 'content/_index.md')
+    2. If it is the index of a section (e.g. 'content/foo/_index.md'), it will:
+       a. return "foo" if the file's frontmatter does not have the cssClass parameter set
+       b. return the value of the cssClass parameter if set in the file's frontmatter
+    3. If it is a non-index leaf of a section (e.g. 'content/foo/bar.md'), it will:
+       a. return the cssClass injection value for its parent section (as described in 2)
+          if the leaf's frontmatter does not have the cssClass parameter set
+       b. return the cssClass injection value for its parent section (as described in 2)
+          with its own cssClass parameter value if set in the frontmatter of the leaf's file
+    4. For arbitrarily nested files (e.g 'content/foo/bar/baz/qux.mf'), it will:
+       a. return the CSS classes for each parent section as outlined in 3; assuming
+          none of the ancestor sections for `qux.md` nor `qux.md` itself have the cssClass
+          parameter set, the return value would be "foo bar baz"
 */}}
 {{- $injectedClass :=  "" -}}
-{{- $currentLink := .Permalink -}}
 {{- $currentParams := .Params -}}
-{{- $bookSection := default "docs" .Site.Params.BookSection -}}
-{{- if eq $bookSection "*" -}}
-    {{- $bookSection = "/" -}}
-{{- end -}}
-{{- with .Site.GetPage $bookSection -}}
-    {{- range (where .Pages "Params.bookhidden" "ne" true) -}}
-        {{- $page := . -}}
-        {{- $filePath := replace .File.Path "\\" "/" -}}
-        {{- $parts := split $filePath "/" -}}
-        {{- $section := index $parts 1 -}}
-        {{- $section = replace $section ".md" "" -}}
-        {{- if in $currentLink $section -}}
-            {{- with $currentParams.cssClass -}}
-                {{- $injectedClass = $currentParams.cssClass -}}
-            {{- else -}}
-                {{- with $page.Params.cssClass -}}
-                    {{- $injectedClass = $page.Params.cssClass -}}
-                {{- else -}}
-                    {{- $injectedClass = $section -}}
+{{/* This implementation only works on content files, not other generated pages, like taxonomy */}}
+{{- with .File -}}
+    {{- $filePath := path.Clean .Path -}}
+    {{- $parentPath := path.Dir $filePath -}}
+    {{- $parts := split $filePath "/" -}}
+    {{- $isTopLevelFile := eq (len $parts) 1 -}}
+    {{- range $section := $parts -}}
+        {{- if (in $section ".md") -}} {{/* Process the leaf file */}}
+            {{- if (ne $section "_index.md") -}}
+                {{- if $isTopLevelFile -}}
+                    {{- with $currentParams.cssClass -}}
+                        {{- $injectedClass = printf "%s %s" $injectedClass . -}}
+                    {{- else -}}
+                        {{- $injectedClass = printf "%s %s" $injectedClass (replace $section ".md" "") -}}
+                    {{- end -}}
+                {{- else -}} {{/* Only inject ancestor section classes unless the page specifies one */}}
+                    {{- with $currentParams.cssClass -}}
+                        {{- $injectedClass = printf "%s %s" $injectedClass . -}}
+                    {{- end -}}
                 {{- end -}}
             {{- end -}}
+        {{- else -}} {{/* Process an ancestor section */}}
+            {{- with $.Site.GetPage $section -}} {{/* The section has an _index.md */}}
+                {{- with .Params.cssClass -}}
+                    {{- $injectedClass = printf "%s %s" $injectedClass . -}}
+                {{- else -}}
+                    {{- $injectedClass = printf "%s %s" $injectedClass $section -}}
+                {{- end -}}
+            {{- else -}} {{/* The section does not have an _index.md */}}
+                {{- $injectedClass = printf "%s %s" $injectedClass $section -}}
+            {{- end -}}
         {{- end -}}
-    {{- end -}}
-{{- end -}}
-{{- return $injectedClass -}}
+    {{ end }}
+{{ end }}
+{{- return (trim $injectedClass " ") -}}


### PR DESCRIPTION
Prior to this PR, the CSS class injection functionality was implemented such that it:

1. Operated only on "book section" children (e.g. `content/docs/foo/bar.md` but not `content/posts/foo.md`)
2. Injected only the first section segment name (or the `cssClass` parameter value if specified in the `_index.md` for that section) - e.g. for `content/docs/foo/bar/baz.md` it would inject `foo`
3. Allowed a user to inject arbitrary classes as defined in the frontmatter of a top level "book section" via the `cssClass` parameter by specifying a space-separated list of class names instead of a single class name.

This commit modifies the `getCssClass` partial which is used to determine what class(es) should be injected by:

1. Reworking the logic to operate only on files (i.e. it will not inject classes into other generated pages like taxonomy)
2. Extending the functionality to operate on all sections, not exclusively those defined as a "book section"
3. Extending the functionality to operate on top level pages, injecting their url segment as the class by default unless the page frontmatter specifies the `cssClass` parameter.
4. Extending the functionality to compose the classes-to-inject all the way up the ancestor chain, using the url segment for each section unless that section has an `_index.md` file which specifies the `cssClass` parameter in its frontmatter.
5. Extending the functionality to allow non-index child pages of a section to append their own class for injection *only* if that page specifies the `cssClass` parameter in its frontmatter.

This should enable more flexible usage of the CSS injection by users.

Resolves #39