### PR TITLE
(MAINT) Fix CSS override partial

### DIFF
--- a/layouts/partials/platen/getCssClass.html
+++ b/layouts/partials/platen/getCssClass.html
@@ -27,7 +27,7 @@
     {{- $parentPath := path.Dir $filePath -}}
     {{- $parts := split $filePath "/" -}}
     {{- $isTopLevelFile := eq (len $parts) 1 -}}
-    {{- range $section := $parts -}}
+    {{- range $index, $section := $parts -}}
         {{- if (in $section ".md") -}} {{/* Process the leaf file */}}
             {{- if (ne $section "_index.md") -}}
                 {{- if $isTopLevelFile -}}
@@ -43,7 +43,8 @@
                 {{- end -}}
             {{- end -}}
         {{- else -}} {{/* Process an ancestor section */}}
-            {{- with $.Site.GetPage $section -}} {{/* The section has an _index.md */}}
+            {{- $segment := printf "/%s" (delimit $parts "/" $index) -}}
+            {{- with $.Site.GetPage $segment -}} {{/* The section has an _index.md */}}
                 {{- with .Params.cssClass -}}
                     {{- $injectedClass = printf "%s %s" $injectedClass . -}}
                 {{- else -}}


### PR DESCRIPTION
Prior to this change, the `getCssClass` partial that provides the CSS override functionality on a per-page and per-section basis was broken if a site had any duplicate section names, even if they have different ancestors.

This change fixes the bug by introducing logic to search for the fully qualified section instead of the section name alone. For example, instead of `concepts`, it searches for `/modules/platen/concepts`.